### PR TITLE
fsm_async_bake: fix typo in Cargo.toml

### DIFF
--- a/async_fsm_bake/Cargo.toml
+++ b/async_fsm_bake/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async_fsm_bake"
 version = "0.1.0"
 edition = "2021"
-licence = "MIT"
+license = "MIT"
 authors = ["Lukasz Lewinski <lewinskilukas@gmail.com>"]
 description = "A CLI tool to generate async_fsm code snippets from plantuml diagram."
 keywords = ["cli", "tool", "snippet", "async_fsm", "async_fsm_bake"]


### PR DESCRIPTION
Fix license typo in async_fsm_bake Cargo.toml file.