### PR TITLE
async_fsm_bake: specify depencencies version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "async_fsm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "log",

--- a/async_fsm_bake/Cargo.toml
+++ b/async_fsm_bake/Cargo.toml
@@ -10,6 +10,6 @@ categories = ["command-line-utilities"]
 include = ["src", "templates"]
 
 [dependencies]
-regex = "*"
-askama = "*"
+regex = "1.11.1"
+askama = "0.14.0"
 clap = { version = "4.5", features = [ "unstable-doc" ]}


### PR DESCRIPTION
To publish crate it's not allowed to use wildchars (*) as a version.